### PR TITLE
Fix inorrect copying of skb head

### DIFF
--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -1255,6 +1255,9 @@ static void __copy_skb_header(struct sk_buff *new, const struct sk_buff *old)
 #ifdef CONFIG_NET_SCHED
 	CHECK_SKB_FIELD(tc_index);
 #endif
+#ifdef CONFIG_SECURITY_TEMPESTA
+	new->tail_lock = 0;
+#endif
 
 }
 


### PR DESCRIPTION
We should not copy value of skb->tail_lock for cloned skb, it should be zero for a new skb. For example in `skb_segment` function we clone skb and then use skb_put on the clonned skb, that leads to BUG_ON if skb->tail_lock is not zero.