### PR TITLE
Fix work with `tail_lock`.

### DIFF
--- a/include/linux/skbuff.h
+++ b/include/linux/skbuff.h
@@ -805,6 +805,9 @@ struct sk_buff {
 #ifdef CONFIG_SKB_EXTENSIONS
 	__u8			active_extensions;
 #endif
+#ifdef CONFIG_SECURITY_TEMPESTA
+        __u8                    tail_lock:1;
+#endif
 	/* fields enclosed in headers_start/headers_end are copied
 	 * using a single memcpy() in __copy_skb_header()
 	 */
@@ -856,10 +859,6 @@ struct sk_buff {
 #ifdef CONFIG_IPV6_NDISC_NODETYPE
 	__u8			ndisc_nodetype:2;
 #endif
-#ifdef CONFIG_SECURITY_TEMPESTA
-	__u8			tail_lock:1;
-#endif
-
 	__u8			ipvs_property:1;
 	__u8			inner_protocol_type:1;
 	__u8			remcsum_offload:1;

--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -1270,6 +1270,9 @@ static struct sk_buff *__skb_clone(struct sk_buff *n, struct sk_buff *skb)
 	n->sk = NULL;
 	__copy_skb_header(n, skb);
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+	C(tail_lock);
+#endif
 	C(len);
 	C(data_len);
 	C(mac_len);


### PR DESCRIPTION
We should not copy skb header, we should not copy
`tail_lock` flag, but we should copy it when we clone skb. So move `tail_lock` flag before `headers_start` and copy it in `__skb_clone` function.