### PR TITLE
Fixed kernel panic under heavy load with low mtu

### DIFF
--- a/net/ipv4/tcp_input.c
+++ b/net/ipv4/tcp_input.c
@@ -5126,9 +5126,20 @@ restart:
 		int copy = min_t(int, SKB_MAX_ORDER(0, 0), end - start);
 		struct sk_buff *nskb;
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+		/*
+		 * This skb can be reused by Tempesta FW. Thus allocate
+		 * space for TCP headers.
+		 */
+		nskb = alloc_skb(copy + MAX_TCP_HEADER, GFP_ATOMIC);
+#else
 		nskb = alloc_skb(copy, GFP_ATOMIC);
+#endif
 		if (!nskb)
 			break;
+#ifdef CONFIG_SECURITY_TEMPESTA
+		skb_reserve(nskb, MAX_TCP_HEADER);
+#endif
 
 		memcpy(nskb->cb, skb->cb, sizeof(skb->cb));
 #ifdef CONFIG_TLS_DEVICE


### PR DESCRIPTION
When `sk_rmem_alloc` above than `sk_rcvbuf` kernel tries to free some memory using `tcp_prune_queue()`. In this case `out_of_order_queue` is first target for collapsing, during collapsing this queue(see `tcp_collapse()`) new skb will be allocated. However, this skb doesn't have space for TCP headers, because in vanilla kernel at this stage skb can't be reused, thus skb doesn't need space for TCP headers. But in Tempesta FW we can reuse received skbs, this implies reused skb must have space for TCP headers, otherwise we will got kernel panic when `push`ing headers.

On my setup can be reproduced with `net.ipv4.tcp_mem = 4096 131072 16777216`