### PR TITLE
Export tso_fragment and skb_copy_tfw_cb() doesn't clear flags now

### DIFF
--- a/include/linux/skbuff.h
+++ b/include/linux/skbuff.h
@@ -964,19 +964,13 @@ enum {
 	SS_F_HTTT2_FRAME_DATA                   = 0x08,
 	/* This skb was already prepared. */
 	SS_F_HTTP2_FRAME_PREPARED               = 0x10,
-	/* HEADERS frame was already prepared for this skb. */
-	SS_F_HTTT2_FRAME_HEADERS_DONE		= 0x20,
-	/* DATA frame was already prepared for this skb. */
-	SS_F_HTTT2_FRAME_DATA_DONE              = 0x40,
 	/* This skb acks new hpack dynamic tbl size. */
-	SS_F_HTTP2_ACK_FOR_HPACK_TBL_RESIZING   = 0x80,
+	SS_F_HTTP2_ACK_FOR_HPACK_TBL_RESIZING   = 0x20,
 	/*
 	 * These flags should be cleared when we copy flags
 	 * from one skb to another one.
 	 */
 	TEMPESTA_SKB_FLAG_CLEAR_MASK	= SS_F_HTTP2_ACK_FOR_HPACK_TBL_RESIZING |
-					  SS_F_HTTT2_FRAME_DATA_DONE |
-					  SS_F_HTTT2_FRAME_HEADERS_DONE |
 					  SS_F_HTTT2_HPACK_TBL_SZ_ENCODED |
 					  SS_F_HTTP2_FRAME_START,
 };
@@ -1037,7 +1031,6 @@ static inline void
 skb_copy_tfw_cb(struct sk_buff *dst, struct sk_buff *src)
 {
 	dst->dev = src->dev;
-        dst->tfw_cb.flags &= (unsigned short)(~TEMPESTA_SKB_FLAG_CLEAR_MASK);
 }
 
 static inline void

--- a/include/net/tcp.h
+++ b/include/net/tcp.h
@@ -585,6 +585,8 @@ enum tcp_queue {
 	TCP_FRAG_IN_WRITE_QUEUE,
 	TCP_FRAG_IN_RTX_QUEUE,
 };
+int tso_fragment(struct sock *sk, struct sk_buff *skb, unsigned int len,
+		 unsigned int mss_now, gfp_t gfp);
 int tcp_fragment(struct sock *sk, enum tcp_queue tcp_queue,
 		 struct sk_buff *skb, u32 len,
 		 unsigned int mss_now, gfp_t gfp);

--- a/net/ipv4/tcp_output.c
+++ b/net/ipv4/tcp_output.c
@@ -2145,8 +2145,8 @@ static bool tcp_snd_wnd_test(const struct tcp_sock *tp,
  * know that all the data is in scatter-gather pages, and that the
  * packet has never been sent out before (and thus is not cloned).
  */
-static int tso_fragment(struct sock *sk, struct sk_buff *skb, unsigned int len,
-			unsigned int mss_now, gfp_t gfp)
+int tso_fragment(struct sock *sk, struct sk_buff *skb, unsigned int len,
+		 unsigned int mss_now, gfp_t gfp)
 {
 	int nlen = skb->len - len;
 	struct sk_buff *buff;
@@ -2196,6 +2196,7 @@ static int tso_fragment(struct sock *sk, struct sk_buff *skb, unsigned int len,
 
 	return 0;
 }
+EXPORT_SYMBOL(tso_fragment);
 
 /* Try to defer sending, if possible, in order to minimize the amount
  * of TSO splitting we do.  View it as a kind of TSO Nagle test.


### PR DESCRIPTION
This changes made accordingly to modified approach of making http2 frames for responses.