### PR TITLE
Pass marked skb to `tempesta_new_clntsk` function

### DIFF
--- a/include/linux/tempesta.h
+++ b/include/linux/tempesta.h
@@ -26,7 +26,7 @@
 typedef void (*TempestaTxAction)(void);
 
 typedef struct {
-	int (*sk_alloc)(struct sock *sk);
+	int (*sk_alloc)(struct sock *sk, struct sk_buff *skb);
 	void (*sk_free)(struct sock *sk);
 	int (*sock_tcp_rcv)(struct sock *sk, struct sk_buff *skb);
 } TempestaOps;
@@ -37,7 +37,7 @@ typedef struct {
 } TempestaMapping;
 
 /* Security hooks. */
-int tempesta_new_clntsk(struct sock *newsk);
+int tempesta_new_clntsk(struct sock *newsk, struct sk_buff *skb);
 void tempesta_register_ops(TempestaOps *tops);
 void tempesta_unregister_ops(TempestaOps *tops);
 

--- a/net/ipv4/tcp_ipv4.c
+++ b/net/ipv4/tcp_ipv4.c
@@ -1586,7 +1586,7 @@ struct sock *tcp_v4_syn_recv_sock(const struct sock *sk, struct sk_buff *skb,
 	 * We need already initialized socket addresses,
 	 * so there is no appropriate security hook.
 	 */
-	if (tempesta_new_clntsk(newsk)) {
+	if (tempesta_new_clntsk(newsk, skb)) {
 		tcp_v4_send_reset(newsk, skb);
 		goto put_and_exit;
 	}

--- a/net/ipv6/tcp_ipv6.c
+++ b/net/ipv6/tcp_ipv6.c
@@ -1382,7 +1382,7 @@ static struct sock *tcp_v6_syn_recv_sock(const struct sock *sk, struct sk_buff *
 	 * We need already initialized socket addresses,
 	 * so there is no appropriate security hook.
 	 */
-	if (tempesta_new_clntsk(newsk)) {
+	if (tempesta_new_clntsk(newsk, skb)) {
 		tcp_v6_send_reset(newsk, skb);
 		inet_csk_prepare_forced_close(newsk);
 		tcp_done(newsk);

--- a/security/tempesta/tempesta_lsm.c
+++ b/security/tempesta/tempesta_lsm.c
@@ -61,7 +61,7 @@ tempesta_unregister_ops(TempestaOps *tops)
 EXPORT_SYMBOL(tempesta_unregister_ops);
 
 int
-tempesta_new_clntsk(struct sock *newsk)
+tempesta_new_clntsk(struct sock *newsk, struct sk_buff *skb)
 {
 	int r = 0;
 
@@ -73,7 +73,7 @@ tempesta_new_clntsk(struct sock *newsk)
 
 	tops = rcu_dereference(tempesta_ops);
 	if (likely(tops))
-		r = tops->sk_alloc(newsk);
+		r = tops->sk_alloc(newsk, skb);
 
 	rcu_read_unlock();
 


### PR DESCRIPTION
We need `skb->mark` to check if we can to create new connection or now.