### PR TITLE
Fix setting mark for tempesta sockets.

### DIFF
--- a/net/ipv4/ip_output.c
+++ b/net/ipv4/ip_output.c
@@ -530,6 +530,15 @@ packet_routed:
 
 	/* TODO : should we use skb->sk here instead of sk ? */
 	skb->priority = sk->sk_priority;
+#ifdef CONFIG_SECURITY_TEMPESTA
+	/*
+	 * Tempesta can set skb->mark for some skbs. And moreover
+	 * sk_mark is never set for Tempesta sockets.
+	 */
+	if (sock_flag(sk, SOCK_TEMPESTA))
+		WARN_ON_ONCE(sk->sk_mark);
+	else
+#endif
 	skb->mark = sk->sk_mark;
 
 	res = ip_local_out(net, sk, skb);


### PR DESCRIPTION
Kernel set skb->mark in `__ip_queue_xmit` using
sk->sk_mark, but for Tempesta sockets we can't
rely on this mechanizm. Tempesta can set skb->mark for some skbs. And moreover sk_mark is never set
for Tempesta sockets. Also we should copy skb->mark when we split skb in tso_fragment/tcp_fragment,
because skb can contain mark which was set by Tempesta.