### PR TITLE
Drop request sock in case when frang block new connection

### DIFF
--- a/include/net/inet_sock.h
+++ b/include/net/inet_sock.h
@@ -87,7 +87,12 @@ struct inet_request_sock {
 				ecn_ok	   : 1,
 				acked	   : 1,
 				no_srccheck: 1,
+#ifdef CONFIG_SECURITY_TEMPESTA
+				smc_ok	   : 1,
+				aborted	   : 1;
+#else
 				smc_ok	   : 1;
+#endif
 	u32                     ir_mark;
 	union {
 		struct ip_options_rcu __rcu	*ireq_opt;

--- a/net/ipv4/tcp_ipv4.c
+++ b/net/ipv4/tcp_ipv4.c
@@ -1587,7 +1587,7 @@ struct sock *tcp_v4_syn_recv_sock(const struct sock *sk, struct sk_buff *skb,
 	 * so there is no appropriate security hook.
 	 */
 	if (tempesta_new_clntsk(newsk, skb)) {
-		tcp_v4_send_reset(newsk, skb);
+		ireq->aborted = true;
 		goto put_and_exit;
 	}
 #endif

--- a/net/ipv4/tcp_minisocks.c
+++ b/net/ipv4/tcp_minisocks.c
@@ -786,7 +786,12 @@ struct sock *tcp_check_req(struct sock *sk, struct sk_buff *skb,
 	return inet_csk_complete_hashdance(sk, child, req, own_req);
 
 listen_overflow:
+#ifdef CONFIG_SECURITY_TEMPESTA
+	if (!sock_net(sk)->ipv4.sysctl_tcp_abort_on_overflow
+	    && !inet_rsk(req)->aborted) {
+#else
 	if (!sock_net(sk)->ipv4.sysctl_tcp_abort_on_overflow) {
+#endif
 		inet_rsk(req)->acked = 1;
 		return NULL;
 	}

--- a/net/ipv6/tcp_ipv6.c
+++ b/net/ipv6/tcp_ipv6.c
@@ -1383,7 +1383,7 @@ static struct sock *tcp_v6_syn_recv_sock(const struct sock *sk, struct sk_buff *
 	 * so there is no appropriate security hook.
 	 */
 	if (tempesta_new_clntsk(newsk, skb)) {
-		tcp_v6_send_reset(newsk, skb);
+		ireq->aborted = true;
 		inet_csk_prepare_forced_close(newsk);
 		tcp_done(newsk);
 		goto out;


### PR DESCRIPTION
We should drop request sock in case when frang block establishing new connection to prevent situation, when we try to establish blocked connection again, when client retransmit last tcp handshake ACK or send some data for such blocked connection.