### PR TITLE
Add tempesta_close_clntsk()

### DIFF
--- a/include/linux/tempesta.h
+++ b/include/linux/tempesta.h
@@ -38,6 +38,7 @@ typedef struct {
 
 /* Security hooks. */
 int tempesta_new_clntsk(struct sock *newsk, struct sk_buff *skb);
+void tempesta_close_clntsk(struct sock *sk);
 void tempesta_register_ops(TempestaOps *tops);
 void tempesta_unregister_ops(TempestaOps *tops);
 

--- a/net/ipv4/tcp_ipv4.c
+++ b/net/ipv4/tcp_ipv4.c
@@ -1588,6 +1588,7 @@ struct sock *tcp_v4_syn_recv_sock(const struct sock *sk, struct sk_buff *skb,
 	 */
 	if (tempesta_new_clntsk(newsk, skb)) {
 		tcp_v4_send_reset(newsk, skb);
+		tempesta_close_clntsk(newsk);
 		goto put_and_exit;
 	}
 #endif

--- a/net/ipv6/tcp_ipv6.c
+++ b/net/ipv6/tcp_ipv6.c
@@ -1384,6 +1384,7 @@ static struct sock *tcp_v6_syn_recv_sock(const struct sock *sk, struct sk_buff *
 	 */
 	if (tempesta_new_clntsk(newsk, skb)) {
 		tcp_v6_send_reset(newsk, skb);
+		tempesta_close_clntsk(newsk);
 		inet_csk_prepare_forced_close(newsk);
 		tcp_done(newsk);
 		goto out;

--- a/security/tempesta/tempesta_lsm.c
+++ b/security/tempesta/tempesta_lsm.c
@@ -81,6 +81,21 @@ tempesta_new_clntsk(struct sock *newsk, struct sk_buff *skb)
 }
 EXPORT_SYMBOL(tempesta_new_clntsk);
 
+void
+tempesta_close_clntsk(struct sock *sk)
+{
+	TempestaOps *tops;
+
+	rcu_read_lock();
+
+	tops = rcu_dereference(tempesta_ops);
+	if (likely(tops))
+		tops->sk_free(sk);
+
+	rcu_read_unlock();
+}
+EXPORT_SYMBOL(tempesta_close_clntsk);
+
 static int
 tempesta_sock_tcp_rcv(struct sock *sk, struct sk_buff *skb)
 {


### PR DESCRIPTION
Function intended to run TempestaOps skfree() callback. At the moment it is used for decrement connection counter in the case of dropping connection by connection limiter (Issue #2084).