### PR TITLE
Reliable memory reserve

### DIFF
--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -5260,10 +5260,10 @@
 	tdfx=		[HW,DRM]
 
 	tempesta_dbmem=	[KNL]
-			Order of 2MB memory blocks reserved on each NUMA node
-			for Tempesta database. Huge pages are used if
-			possible. Minimum value to start Tempesta is 4 (32MB).
-			Default is 8, i.e. 512MB is reserved.
+			Amount of memory reserved on all NUMA nodes for Tempesta
+			database. The amount is divided between NUMA nodes.
+			Huge pages are used if possible. Minimum value to start
+			Tempesta is 32MB per node. Default is 512MB.
 
 	test_suspend=	[SUSPEND][,N]
 			Specify "mem" (for Suspend-to-RAM) or "standby" (for

--- a/arch/x86/boot/compressed/kaslr.c
+++ b/arch/x86/boot/compressed/kaslr.c
@@ -88,6 +88,10 @@ static bool memmap_too_large;
  */
 static u64 mem_limit;
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+static u64 tempesta_dbmem_sz;
+#endif
+
 /* Number of immovable memory regions */
 static int num_immovable_mem;
 
@@ -302,6 +306,17 @@ static void handle_mem_options(void)
 		} else if (!strcmp(param, "efi_fake_mem")) {
 			mem_avoid_memmap(PARSE_EFI, val);
 		}
+#ifdef CONFIG_SECURITY_TEMPESTA
+		else if (!strcmp(param, "tempesta_dbmem")) {
+			char *p = val;
+
+			tempesta_dbmem_sz = round_up(memparse(p, &p),
+						     HPAGE_SIZE);
+			/* Don't clamp memory region when reserved less 32M */
+			if (tempesta_dbmem_sz < SZ_32M)
+				tempesta_dbmem_sz = 0;
+		}
+#endif
 	}
 
 	free(tmp_cmdline);
@@ -557,6 +572,29 @@ process_gb_huge_pages(struct mem_vector *region, unsigned long image_size)
 	}
 }
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+static void
+tempesta_clamp_region(struct mem_vector *region)
+{
+	if (!tempesta_dbmem_sz)
+		return;
+
+	if (region->size > tempesta_dbmem_sz) {
+		region->size -= tempesta_dbmem_sz;
+		/* Clamp only one region, it must enough. */
+		tempesta_dbmem_sz = 0;
+	}
+}
+
+static void
+post_process_region(struct mem_vector region, unsigned long image_size)
+{
+	/* Reserve space for Tempesta. */
+	tempesta_clamp_region(&region);
+	process_gb_huge_pages(&region, image_size);
+}
+#endif
+
 static u64 slots_fetch_random(void)
 {
 	unsigned long slot;
@@ -610,14 +648,22 @@ static void __process_mem_region(struct mem_vector *entry,
 
 		/* If nothing overlaps, store the region and return. */
 		if (!mem_avoid_overlap(&region, &overlap)) {
+#ifdef CONFIG_SECURITY_TEMPESTA
+			post_process_region(region, image_size);
+#else
 			process_gb_huge_pages(&region, image_size);
+#endif
 			return;
 		}
 
 		/* Store beginning of region if holds at least image_size. */
 		if (overlap.start >= region.start + image_size) {
 			region.size = overlap.start - region.start;
+#ifdef CONFIG_SECURITY_TEMPESTA
+			post_process_region(region, image_size);
+#else
 			process_gb_huge_pages(&region, image_size);
+#endif
 		}
 
 		/* Clip off the overlapping region and start over. */

--- a/init/main.c
+++ b/init/main.c
@@ -822,6 +822,13 @@ static void __init report_meminit(void)
  */
 static void __init mm_init(void)
 {
+#ifdef CONFIG_SECURITY_TEMPESTA
+	/*
+	 * Tempesta: reserve memory at boot stage to get continous address
+	 * space. Do it while memblock is available.
+	 */
+	tempesta_reserve_pages();
+#endif
 	/*
 	 * page_ext requires contiguous pages,
 	 * bigger than MAX_ORDER unless SPARSEMEM.
@@ -830,14 +837,6 @@ static void __init mm_init(void)
 	init_debug_pagealloc();
 	report_meminit();
 	mem_init();
-
-#ifdef CONFIG_SECURITY_TEMPESTA
-	/*
-	 * Tempesta: reserve pages just when zones are initialized
-	 * to get continous address space of huge pages.
-	 */
-	tempesta_reserve_pages();
-#endif
 
 	kmem_cache_init();
 	kmemleak_init();

--- a/mm/tempesta_mm.c
+++ b/mm/tempesta_mm.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta Memory Reservation
  *
- * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -22,41 +22,45 @@
 #include <linux/tempesta.h>
 #include <linux/topology.h>
 #include <linux/vmalloc.h>
+#include <linux/memblock.h>
 
 #include "internal.h"
 
-#define MAX_PGORDER		16	/* 128GB per one table */
-#define MIN_PGORDER		4	/* 32MB */
-#define DEFAULT_PGORDER		8	/* 512MB */
-/* Modern processors support up to 1.5TB of RAM, be ready for 2TB. */
-#define GREEDY_ARNUM		(1024 * 1024 + 1)
-#define PGNUM			(1 << pgorder)
-#define PGNUM4K			(PGNUM * (1 << HUGETLB_PAGE_ORDER))
+#define MAX_MEMSZ		65536 * HPAGE_SIZE /* 128GB per node */
+#define MIN_MEMSZ		16 * HPAGE_SIZE	/* 32MB per node */
+#define DEFAULT_MEMSZ		256 * HPAGE_SIZE /* 512MB */
 
-static int pgorder = DEFAULT_PGORDER;
-static gfp_t gfp_f = GFP_HIGHUSER | __GFP_COMP | __GFP_THISNODE | __GFP_ZERO
-		     | __GFP_RETRY_MAYFAIL;
+static unsigned long dbmem = DEFAULT_MEMSZ;
 static TempestaMapping map[MAX_NUMNODES];
-/*
- * Modern x86-64 has not more than 512GB RAM per physical node.
- * This is very large amount of memory, but it will be freed when
- * initialization phase ends.
- */
-static struct page *greedy[GREEDY_ARNUM] __initdata = { 0 };
+
+static unsigned long
+__dbsize_mb(unsigned long size)
+{
+	if (size >= SZ_1M)
+		return size / SZ_1M;
+
+	return 0;
+}
 
 static int __init
 tempesta_setup_pages(char *str)
 {
-	get_option(&str, &pgorder);
-	if (pgorder < MIN_PGORDER) {
-		pr_err("Tempesta: bad dbmem value %d, must be [%d:%d]\n",
-		       pgorder, MIN_PGORDER, MAX_PGORDER);
-		pgorder = MIN_PGORDER;
+	unsigned long min = __dbsize_mb(MIN_MEMSZ) * nr_online_nodes;
+	unsigned long max = __dbsize_mb(MAX_MEMSZ) * nr_online_nodes;
+	unsigned long raw_dbmem = memparse(str, NULL);
+
+	/* Count memory per node */
+	dbmem = round_up(raw_dbmem / nr_online_nodes, HPAGE_SIZE);
+
+	if (dbmem < MIN_MEMSZ) {
+		pr_err("Tempesta: bad dbmem value %lu(%luM), must be [%luM:%luM]"
+		       "\n", raw_dbmem, __dbsize_mb(raw_dbmem), min, max);
+		dbmem = MIN_MEMSZ;
 	}
-	if (pgorder > MAX_PGORDER) {
-		pr_err("Tempesta: bad dbmem value %d, must be [%d:%d]\n",
-		       pgorder, MIN_PGORDER, MAX_PGORDER);
-		pgorder = MAX_PGORDER;
+	if (dbmem > MAX_MEMSZ) {
+		pr_err("Tempesta: bad dbmem value %lu(%luM), must be [%luM:%luM]"
+		       "\n", raw_dbmem, __dbsize_mb(raw_dbmem), min, max);
+		dbmem = MAX_MEMSZ;
 	}
 
 	return 1;
@@ -64,162 +68,42 @@ tempesta_setup_pages(char *str)
 __setup("tempesta_dbmem=", tempesta_setup_pages);
 
 /**
- * The code is somewhat stollen from mm/hugetlb.c.
- */
-static struct page *
-tempesta_alloc_hpage(int nid)
-{
-	struct page *p;
-
-	p = alloc_pages_node(nid, gfp_f, HUGETLB_PAGE_ORDER);
-	if (!p)
-		return NULL;
-
-	count_vm_event(HTLB_BUDDY_PGALLOC);
-
-	__ClearPageReserved(p);
-
-	return p;
-}
-
-static void
-tempesta_free_hpage(struct page *p)
-{
-	__free_pages(p, HUGETLB_PAGE_ORDER);
-}
-
-/**
- * Greedely alloc huge pages and try to find continous region organized
- * by sorted set of allocated pages. When the region is found, all pages
- * out of it are returned to system.
- */
-static struct page *
-tempesta_alloc_contmem(int nid)
-{
-	long min = -1, start = -1, curr = 0, end = -1, max = -1;
-	struct page *p;
-
-	while (1) {
-		p = tempesta_alloc_hpage(nid);
-		if (!p)
-			goto err;
-		curr = ((long)page_address(p) - PAGE_OFFSET) >> HPAGE_SHIFT;
-		/*
-		 * The first kernel mapped page is always reserved.
-		 * Keep untouched (zero) bounds for faster lookups.
-		 */
-		BUG_ON(curr < 1 || curr >= GREEDY_ARNUM);
-		greedy[curr] = p;
-
-		/* First time initialization. */
-		if (min < 0) {
-			min = start = end = max = curr;
-		} else {
-			/* Update bounds for faster pages return. */
-			if (min > curr)
-				min = curr;
-			if (max < curr)
-				max = curr;
-			/* Update continous memory segment bounds. */
-			if (curr == end + 1) {
-				while (end <= max && greedy[end + 1])
-					++end;
-			}
-			else if (curr + 1 == start) {
-				while (start >= min && greedy[start - 1])
-					--start;
-			}
-			else {
-				/* Try to find new continous segment. */
-				long i, d_max = 0, good_start = start = min;
-				for (i = min; i <= max; ++i) {
-					if (greedy[i]) {
-						if (start == -1)
-							start = i;
-						end = i;
-						if (i - start + 1 == PGNUM)
-							break;
-						continue;
-					}
-
-					if (start > 0 && end - start > d_max) {
-						good_start = start;
-						d_max = end - start;
-					}
-					start = -1;
-				}
-				if (end - start < d_max) {
-					start = good_start;
-					end = start + d_max;
-				}
-			}
-		}
-
-		if (end - start + 1 == PGNUM)
-			break; /* continous space is built! */
-	}
-
-	/* Return unnecessary pages. */
-	BUG_ON(min < 0 || start < 0 || end < 0 || max < 0);
-	for ( ; min < start; ++min)
-		if (greedy[min]) {
-			tempesta_free_hpage(greedy[min]);
-			greedy[min] = NULL;
-		}
-	for ( ; max > end; --max)
-		if (greedy[max]) {
-			tempesta_free_hpage(greedy[max]);
-			greedy[max] = NULL;
-		}
-	return greedy[start];
-
-err:
-	pr_err("Tempesta: cannot allocate %u continous huge pages at node"
-	       " %d\n", PGNUM, nid);
-	for ( ; min >= 0 && min <= max; ++min)
-		if (greedy[min]) {
-			tempesta_free_hpage(greedy[min]);
-			greedy[min] = NULL;
-		}
-	return NULL;
-}
-
-/**
- * Allocate continous virtual space of huge pages for Tempesta.
- * We do not use giantic 1GB pages since not all modern x86-64 CPUs
- * allows them in virtualized mode.
- *
- * TODO try firstly to allocate giantic pages, next huge pages and finally
- * fallback to common 4KB pages allocation if previous tries failed.
+ * Reserve physically contiguous per-node blocks of memory for Tempesta DB.
  */
 void __init
 tempesta_reserve_pages(void)
 {
 	int nid;
-	struct page *p;
+	void *addr;
 
 	for_each_online_node(nid) {
-		p = tempesta_alloc_contmem(nid);
-		if (!p)
+		addr = memblock_alloc_try_nid_raw(dbmem, HPAGE_SIZE,
+						  MEMBLOCK_LOW_LIMIT,
+						  MEMBLOCK_ALLOC_ANYWHERE,
+						  nid);
+		if (!addr) {
+			pr_err("Tempesta: can't reserve %lu memory at node %d"
+			       "\n", __dbsize_mb(dbmem), nid);
 			goto err;
+		}
 
-		map[nid].addr = (unsigned long)page_address(p);
-		map[nid].pages = PGNUM4K;
-
-		pr_info("Tempesta: allocated huge pages space %pK %luMB at node"
-			" %d\n", page_address(p),
-			PGNUM4K * PAGE_SIZE / (1024 * 1024), nid);
+		map[nid].addr = (unsigned long)addr;
+		map[nid].pages = dbmem / PAGE_SIZE;
+		pr_info("Tempesta: reserved space %luMB addr %p at node %d\n",
+			__dbsize_mb(dbmem), addr, nid);
 	}
 
 	return;
+
 err:
 	for_each_online_node(nid) {
-		struct page *pend;
+		phys_addr_t phys_addr;
+
 		if (!map[nid].addr)
 			continue;
-		for (p = virt_to_page(map[nid].addr), pend = p + PGNUM4K;
-		     p < pend; p += 1 << HUGETLB_PAGE_ORDER)
-			tempesta_free_hpage(p);
+
+		phys_addr = virt_to_phys((void *)map[nid].addr);
+		memblock_free(phys_addr, map[nid].pages * PAGE_SIZE);
 	}
 	memset(map, 0, sizeof(map));
 }
@@ -231,7 +115,6 @@ void __init
 tempesta_reserve_vmpages(void)
 {
 	int nid, maps = 0;
-	size_t vmsize = PGNUM * (1 << HPAGE_SHIFT);
 
 	for_each_online_node(nid)
 		maps += !!map[nid].addr;
@@ -241,19 +124,19 @@ tempesta_reserve_vmpages(void)
 		return;
 
 	for_each_online_node(nid) {
-		pr_warn("Tempesta: allocate %u vmalloc pages at node %d\n",
-			PGNUM4K, nid);
+		pr_warn("Tempesta: allocate %lu vmalloc pages at node %d\n",
+			__dbsize_mb(dbmem), nid);
 
-		map[nid].addr = (unsigned long)vzalloc_node(vmsize, nid);
+		map[nid].addr = (unsigned long)vzalloc_node(dbmem, nid);
 		if (!map[nid].addr)
 			goto err;
-		map[nid].pages = PGNUM4K;
+		map[nid].pages = dbmem / PAGE_SIZE;
 	}
 
 	return;
 err:
 	pr_err("Tempesta: cannot vmalloc area of %lu bytes at node %d\n",
-	       vmsize, nid);
+	       dbmem, nid);
 	for_each_online_node(nid)
 		if (map[nid].addr)
 			vfree((void *)map[nid].addr);


### PR DESCRIPTION
This patch consist of two parts, first is adjusting of KASLR for reserve huge amount of continuous pages. We clamp the max offset of KASLR's point where kernel is unpacked. For instance, there is the memory region 14G we need to reserve 12G, max offset where kernel may be placed is 14G-12G = 2G.

The second part is memory reserve using memblock API. This is more reliable than using buddy for such allocations. However, on NUMA setup sometimes we still have issues with KASLR, when trying to allocate 70-80% of the memory. With disabled KASLR allocation more reliable on NUMA machine.