### PR TITLE
Close connection in case of ENOMEM

### DIFF
--- a/include/net/tcp.h
+++ b/include/net/tcp.h
@@ -1905,7 +1905,7 @@ static inline void tcp_push_pending_frames(struct sock *sk)
 
 		mss_now = tcp_current_mss(sk);
 		result = sk->sk_fill_write_queue(sk, mss_now, 0);
-		if (unlikely(result < 0 && result != -ENOMEM)) {
+		if (unlikely(result < 0)) {
 			tcp_tfw_handle_error(sk, result);
 			return;
 		}

--- a/net/ipv4/tcp_output.c
+++ b/net/ipv4/tcp_output.c
@@ -2808,8 +2808,6 @@ static bool tcp_write_xmit(struct sock *sk, unsigned int mss_now, int nonagle,
 #ifdef CONFIG_SECURITY_TEMPESTA
 		result = tcp_tfw_sk_write_xmit(sk, skb, mss_now);
 		if (unlikely(result)) {
-			if (result == -ENOMEM)
-				break; /* try again next time */
 			tcp_tfw_handle_error(sk, result);
 			return false;
 		}
@@ -3507,6 +3505,7 @@ void sk_forced_mem_schedule(struct sock *sk, int size)
 	if (mem_cgroup_sockets_enabled && sk->sk_memcg)
 		mem_cgroup_charge_skmem(sk->sk_memcg, amt);
 }
+EXPORT_SYMBOL(sk_forced_mem_schedule);
 
 /* Send a FIN. The caller locks the socket for us.
  * We should try to send a FIN packet really hard, but eventually give up.
@@ -4202,8 +4201,7 @@ int tcp_write_wakeup(struct sock *sk, int mib)
 #ifdef CONFIG_SECURITY_TEMPESTA
 		err = tcp_tfw_sk_write_xmit(sk, skb, mss);
 		if (unlikely(err)) {
-			if (err != -ENOMEM)
-				tcp_tfw_handle_error(sk, err);
+			tcp_tfw_handle_error(sk, err);
 			return err;
 		}
 #endif


### PR DESCRIPTION
According our private discussion:
- there is no sence to try to send some data later in case of ENOMEM, it is better to drop connection.
- there are a lot of bugs when we try to reenter to some functions after ENOMEM, because there functions are not reetable. Now we close connection in case of ENOMEM same as
we do it in case of other errors.