### PR TITLE
Remove WINDOW_UPDATE processing after connection is closing

### DIFF
--- a/include/net/sock.h
+++ b/include/net/sock.h
@@ -523,8 +523,7 @@ struct sock {
 				 * and receiver window.
 				 */
 	int			(*sk_fill_write_queue)(struct sock *sk,
-						       unsigned int mss_now,
-						       int ss_action);
+						       unsigned int mss_now);
 				/*
 				 * Tempesta FW callback to free all private
 				 * resources associated with socket.

--- a/include/net/tcp.h
+++ b/include/net/tcp.h
@@ -1904,7 +1904,7 @@ static inline void tcp_push_pending_frames(struct sock *sk)
 		int result;
 
 		mss_now = tcp_current_mss(sk);
-		result = sk->sk_fill_write_queue(sk, mss_now, 0);
+		result = sk->sk_fill_write_queue(sk, mss_now);
 		if (unlikely(result < 0)) {
 			tcp_tfw_handle_error(sk, result);
 			return;


### PR DESCRIPTION
Since we decide to don't process WINDOW_UPDATE frames after connection is closing (and don't send error response in case when http2 or tcp window is exceeded) we don't need to pass close type to `sk_fill_write_queue`. Now we close or shutdown socket immediately after trying to send error response even if response was not sent.