### PR TITLE
Rename socket flag.

### DIFF
--- a/include/net/sock.h
+++ b/include/net/sock.h
@@ -890,10 +890,10 @@ enum sock_flags {
 	SOCK_TEMPESTA_HAS_DATA, /* The socket has data in Tempesta FW
 				 * write queue.
 				 */
-	SOCK_TEMPESTA_IS_CLOSING, /* The socket is closing by Tempesta FW
-				   * from `ss_do_close`. `tcp_done` should
-				   * not be called from the kernel code.
-				   */
+	SOCK_TEMPESTA_IN_USE, /* Currently socket is used by Tempesta FW.
+			       * `tcp_done` should not be called from the
+			       * kernel code.
+			       */
 #endif
 };
 

--- a/include/net/tcp.h
+++ b/include/net/tcp.h
@@ -1890,14 +1890,14 @@ tcp_tfw_handle_error(struct sock *sk, int error)
 	sk->sk_error_report(sk);
 	tcp_write_queue_purge(sk);
 	/*
-	 * SOCK_TEMPESTA_IS_CLOSING is set from `ss_do_close`
-	 * or `ss_do_shutdown` function from Tempesta FW code.
-	 * We should not call `tcp_done` if error occurs during
-	 * one of this function, just set socket state to TCP_CLOSE,
+	 * SOCK_TEMPESTA_IN_USE is set when function is called
+	 * from Tempesta FW code.
+	 * We should not call `tcp_done` if error occurs when
+	 * Tempesta FW uses socket, just set socket state to TCP_CLOSE,
 	 * clear timers and socket write queue. Socket will be
-	 * closed in one of this function.
+	 * closed later from Tempesta FW code.
 	 */
-	if (unlikely(sock_flag(sk, SOCK_TEMPESTA_IS_CLOSING))) {
+	if (unlikely(sock_flag(sk, SOCK_TEMPESTA_IN_USE))) {
 		tcp_set_state(sk, TCP_CLOSE);
 		tcp_clear_xmit_timers(sk);
 	} else {


### PR DESCRIPTION
Previously we use `SOCK_TEMPESTA_IS_CLOSING` flag to prevent `tcp_done` call from Tempesta FW `ss_don_close` and `ss_do_shutdown` procedures. But now it is also used to prevent `tcp_done` call during WINDOW_UPDATE frame processing, so rename this flag and chanfe comments.