### PR TITLE
Fix `tcp_can_coalesce_send_queue_head` function

### DIFF
--- a/net/ipv4/tcp_output.c
+++ b/net/ipv4/tcp_output.c
@@ -2343,13 +2343,20 @@ static inline void tcp_mtu_check_reprobe(struct sock *sk)
 static bool tfw_tcp_skb_can_collapse(struct sock *sk, struct sk_buff *skb,
 				     struct sk_buff *next)
 {
-	BUG_ON(!sock_flag(sk, SOCK_TEMPESTA));
+	if (!sock_flag(sk, SOCK_TEMPESTA))
+		return true;
 
-	if (!tcp_skb_is_last(sk, skb)
-	    && ((skb_tfw_tls_type(skb) != skb_tfw_tls_type(next))
-		|| (skb->mark != next->mark)
-		|| (((skb_shinfo(skb)->tx_flags & SKBTX_SHARED_FRAG)
-		    != (skb_shinfo(next)->tx_flags & SKBTX_SHARED_FRAG)))))
+	if (tcp_skb_is_last(sk, skb))
+		return true;
+
+	if (skb_tfw_tls_type(skb) != skb_tfw_tls_type(next))
+		return false;
+
+	if (skb->mark != next->mark)
+		return false;
+
+	if ((skb_shinfo(skb)->tx_flags & SKBTX_SHARED_FRAG) !=
+	    (skb_shinfo(next)->tx_flags & SKBTX_SHARED_FRAG))
 		return false;
 
 	return true;
@@ -2367,8 +2374,7 @@ static bool tcp_can_coalesce_send_queue_head(struct sock *sk, int len)
 			break;
 
 #ifdef CONFIG_SECURITY_TEMPESTA
-		if (sock_flag(sk, SOCK_TEMPESTA)
-		    && !tfw_tcp_skb_can_collapse(sk, skb, next))
+		if (!tfw_tcp_skb_can_collapse(sk, skb, next))
 			return false;
 #endif
 

--- a/net/ipv4/tcp_output.c
+++ b/net/ipv4/tcp_output.c
@@ -2338,6 +2338,25 @@ static inline void tcp_mtu_check_reprobe(struct sock *sk)
 	}
 }
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+
+static bool tfw_tcp_skb_can_collapse(struct sock *sk, struct sk_buff *skb,
+				     struct sk_buff *next)
+{
+	BUG_ON(!sock_flag(sk, SOCK_TEMPESTA));
+
+	if (!tcp_skb_is_last(sk, skb)
+	    && ((skb_tfw_tls_type(skb) != skb_tfw_tls_type(next))
+		|| (skb->mark != next->mark)
+		|| (((skb_shinfo(skb)->tx_flags & SKBTX_SHARED_FRAG)
+		    != (skb_shinfo(next)->tx_flags & SKBTX_SHARED_FRAG)))))
+		return false;
+
+	return true;
+}
+
+#endif
+
 static bool tcp_can_coalesce_send_queue_head(struct sock *sk, int len)
 {
 	struct sk_buff *skb, *next;
@@ -2347,16 +2366,14 @@ static bool tcp_can_coalesce_send_queue_head(struct sock *sk, int len)
 		if (len <= skb->len)
 			break;
 
-		if (unlikely(TCP_SKB_CB(skb)->eor) || tcp_has_tx_tstamp(skb))
-			return false;
 #ifdef CONFIG_SECURITY_TEMPESTA
-		/* Do not coalesce tempesta skbs with tls type or set mark. */
-		if ((next != ((struct sk_buff *)&(sk)->sk_write_queue))
-		    && ((skb_tfw_tls_type(skb) != skb_tfw_tls_type(next))
-			|| (sock_flag(sk, SOCK_TEMPESTA)
-			    && (skb->mark != next->mark))))
+		if (sock_flag(sk, SOCK_TEMPESTA)
+		    && !tfw_tcp_skb_can_collapse(sk, skb, next))
 			return false;
 #endif
+
+		if (unlikely(TCP_SKB_CB(skb)->eor) || tcp_has_tx_tstamp(skb))
+			return false;
 
 		len -= skb->len;
 	}


### PR DESCRIPTION
- We can coalesce only skbs with the same SKBTX_SHARED_FRAG, so we should check it in `tcp_can_coalesce_send_queue_head`.
- Move all checks to the separate function.