### PR TITLE
fix: do not call `local_bh_(enable/disable)()` when IRQ is disabled

### DIFF
--- a/arch/x86/kernel/fpu/core.c
+++ b/arch/x86/kernel/fpu/core.c
@@ -163,7 +163,8 @@ void kernel_fpu_begin_mask(unsigned int kfpu_mask)
 	 * preciseely that softirq uses FPU, so we have to disable softirq as
 	 * well as task preemption.
 	 */
-	local_bh_disable();
+	if (!irqs_disabled())
+		local_bh_disable();
 #endif
 	preempt_disable();
 
@@ -188,7 +189,8 @@ void kernel_fpu_end(void)
 
 	preempt_enable();
 #ifdef CONFIG_SECURITY_TEMPESTA
-	local_bh_enable();
+	if (!irqs_disabled())
+		local_bh_enable();
 #endif
 }
 EXPORT_SYMBOL_GPL(kernel_fpu_end);


### PR DESCRIPTION
When IRQ is disabled Tempesta must not call BH enable/disable to not trigger SoftIRQ work in section where IRQ is disabled. `extract_entropy` protected with spinlock and disabled IRQ prevents `extract_entropy()` from SoftIRQ triggering/scheduling, but Tempesta's patch breaks this logic enabling SoftIRQ in `kernel_fpu_end()`, that fixed it this patch.